### PR TITLE
fix: autolinking when using Xcode 12

### DIFF
--- a/react-native-blind-threshold-bls.podspec
+++ b/react-native-blind-threshold-bls.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.ios.vendored_library = 'ios/Libraries/libblind_threshold_bls.a'
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   # ...
   # s.dependency "..."
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on React-Core directly instead of React. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116