### PR TITLE
BLS blinding with external randomness

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ To accomodate JNA, add the following to the consuming app's proguard rules:
 -keep class com.sun.jna.* { *; }
 -keepclassmembers class * extends com.sun.jna.* { public *; }
 ```
+
+## Building
+
+### Android
+
+To build the Android library, you can use the `gradlew` script.
+
+```shell
+cd android
+chmod u+x gradlew
+./gradlew assembleDebug
+```

--- a/android/src/main/java/org/celo/BlindThresholdBlsModule.java
+++ b/android/src/main/java/org/celo/BlindThresholdBlsModule.java
@@ -36,24 +36,22 @@ public class BlindThresholdBlsModule extends ReactContextBaseJavaModule {
         return "BlindThresholdBls";
     }
 
-    // TODO add support for multilpe outstanding blind calls
+    // Blind the message
+    // @randomness allows caller to provide deterministic form of randomness
     @ReactMethod
-    public void blindMessage(String message, Promise promise) {
+    public void blindMessage(String message, String randomness, Promise promise) {
         try {
             Log.d(TAG, "Preparing blind message buffers");
             byte[] messageBytes = Base64.decode(message, Base64.DEFAULT);
             messageBuf = new Buffer(messageBytes);
             Buffer blindedMessageBuf = new Buffer();
 
-            Log.d(TAG, "Preparing blinding seed");
-            Random random = new Random();
-            byte[] seed = new byte[32];
-            random.nextBytes(seed);
-            Buffer seedBuf = new Buffer(seed);
+            byte[] randomnessBytes = Base64.decode(randomness, Base64.DEFAULT);
+            Buffer randomnessBuf = new Buffer(randomnessBytes);
 
             Log.d(TAG, "Calling blind");
             blindingFactor = new PointerByReference();
-            blind(messageBuf, seedBuf, blindedMessageBuf, blindingFactor);
+            blind(messageBuf, randomnessBuf, blindedMessageBuf, blindingFactor);
 
             Log.d(TAG, "Blind call done, retrieving blinded message from buffer");
             byte[] blindedMessageBytes = blindedMessageBuf.getMessage();
@@ -63,6 +61,23 @@ public class BlindThresholdBlsModule extends ReactContextBaseJavaModule {
             free_vector(blindedMessageBuf.message, blindedMessageBuf.len);
 
             promise.resolve(b64BlindedMessage);
+        } catch (Exception e) {
+            Log.e(TAG, "Exception while blinding the message: " + e.getMessage());
+            promise.reject(e.getMessage());
+        }
+    }
+
+    // TODO add support for multilpe outstanding blind calls
+    @ReactMethod
+    public void blindMessage(String message, Promise promise) {
+        try {
+            Log.d(TAG, "Preparing blinding seed");
+            Random random = new Random();
+            byte[] seed = new byte[32];
+            random.nextBytes(seed);
+            String randomness = Base64.encodeToString(seed, Base64.DEFAULT);
+
+            blindMessage(message, randomness, promise);
         } catch (Exception e) {
             Log.e(TAG, "Exception while blinding the message: " + e.getMessage());
             promise.reject(e.getMessage());

--- a/android/src/main/java/org/celo/BlindThresholdBlsPackage.java
+++ b/android/src/main/java/org/celo/BlindThresholdBlsPackage.java
@@ -20,4 +20,9 @@ public class BlindThresholdBlsPackage implements ReactPackage {
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
+    
+    @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 declare namespace BlindThresholdBls {
   function blindMessage(message: string): Promise<string>;
+  function blindMessage(message: string, random: string): Promise<string>;
   function unblindMessage(
     base64BlindedSignature: string,
     base64SignerPublicKey: string

--- a/ios/BlindThresholdBls.m
+++ b/ios/BlindThresholdBls.m
@@ -14,6 +14,7 @@ RCT_EXPORT_MODULE()
 // TODO add support for multiple outstanding blind calls
 RCT_REMAP_METHOD(blindMessage,
                  message:(NSString *) message
+                 randomness:(NSString *) randomness
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -27,18 +28,14 @@ RCT_REMAP_METHOD(blindMessage,
     blindedMessageBuf.ptr = NULL;
     blindedMessageBuf.len = 0;
     
-    RCTLogInfo(@"Preparing blinding seed");
-    uint8_t *seedData = malloc(sizeof(uint8_t) * 32);
-    int status = SecRandomCopyBytes(kSecRandomDefault, 32, seedData);
-    if (status != errSecSuccess) {
-      [NSException raise:@"Random bytes copy failed" format:@"status code %d", status];
-    }
-    Buffer seedBuf;
-    seedBuf.ptr = seedData;
-    seedBuf.len = 32;
+    RCTLogInfo(@"Preparing randomness buffer");
+    NSData *randomnessData = [[NSData alloc] initWithBase64EncodedString:randomness options:0];
+    Buffer randomnessBuf;
+    randomnessBuf.ptr = [BlindThresholdBls nsDataToByteArray:randomnessData];
+    randomnessBuf.len = [randomnessData length];
 
     RCTLogInfo(@"Calling blind");
-    blind(&messageBuf, &seedBuf, &blindedMessageBuf, &blindingFactor);
+    blind(&messageBuf, &randomnessBuf, &blindedMessageBuf, &blindingFactor);
 
     RCTLogInfo(@"Blind call done, retrieving blinded message from buffer");
     const size_t blindedMessageLen = blindedMessageBuf.len;
@@ -48,8 +45,8 @@ RCT_REMAP_METHOD(blindMessage,
     NSString *blindedMessageBase64 = [blindedMessageData base64EncodedStringWithOptions:0];
     
     RCTLogInfo(@"Cleaning Up Memory");
+    free_vector(randomnessBuf.ptr, randomnessBuf.len)
     free_vector(blindedMessagePtr, blindedMessageLen);
-    free(seedBuf.ptr);
     
     resolve(blindedMessageBase64);
   }
@@ -60,6 +57,42 @@ RCT_REMAP_METHOD(blindMessage,
   }
 }
 
+// TODO add support for multiple outstanding blind calls
+RCT_REMAP_METHOD(blindMessage,
+                 message:(NSString *) message
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  @try {
+    RCTLogInfo(@"Preparing blinding seed");
+    uint8_t *seedData = malloc(sizeof(uint8_t) * 32);
+    int status = SecRandomCopyBytes(kSecRandomDefault, 32, seedData);
+    if (status != errSecSuccess) {
+      [NSException raise:@"Random bytes copy failed" format:@"status code %d", status];
+    }
+    Buffer seedBuf;
+    seedBuf.ptr = seedData;
+    seedBuf.len = 32;
+    
+    // Convert randomness to base64 encoded string    
+    const size_t randomLen = seedBuf.len;
+    const uint8_t* randomPtr = seedBuf.ptr;
+    NSMutableData* randomData = [NSMutableData dataWithCapacity:randomLen];
+    [randomData appendBytes:randomPtr length:randomLen];
+    NSString *randomBase64 = [randomData base64EncodedStringWithOptions:0];
+
+    RCTLogInfo(@"Calling blindMessage");
+    blindMessage(&message, &randomBase64, &resolver, &rejecter);
+    
+    RCTLogInfo(@"Cleaning Up Memory");
+    free(seedBuf.ptr);
+  }
+  @catch (NSException *exception) {
+    RCTLogInfo(@"Exception while blinding the message: %@", exception.reason); 
+    NSError *error = [NSError errorWithDomain:@"org.celo.mobile" code:500 userInfo:nil];
+    reject(@"Blinding error", exception.reason, error);
+  }
+}
 
 RCT_REMAP_METHOD(unblindMessage,
                  base64BlindedSignature:(NSString *) base64BlindedSignature


### PR DESCRIPTION
https://app.zenhub.com/workspaces/identity-sprint-board-61015de9a849530010b49fc6/issues/celo-org/celo-monorepo/7950

The CAP team needs the ability to provide a custom blinding factor when instantiating a blinding client so that they can use the DEK for blinding ODIS requests.

This will require changes to the underlying Rust API. The CAP team will try to make these changes themselves, but will need a point of contact from the Crypto team for questions and code review. This ticket is to track that POC work.

Note: This will require adding a custom blinding factor in the react native library
https://github.com/celo-org/react-native-blind-threshold-bls#cc36392